### PR TITLE
docs: make the README understandable at a glance

### DIFF
--- a/.github/assets/overview.svg
+++ b/.github/assets/overview.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="460" viewBox="0 0 1200 460" role="img" aria-labelledby="title desc">
+  <title id="title">MCP Switch overview</title>
+  <desc id="desc">Local and remote MCP servers connect through one self-hosted MCP Switch endpoint to web AI clients.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fffafc"/>
+      <stop offset="1" stop-color="#f4f1ff"/>
+    </linearGradient>
+    <linearGradient id="switch" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#d94f86"/>
+      <stop offset="1" stop-color="#7868d8"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-color="#322947" flood-opacity=".13"/>
+    </filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0 0 10 5 0 10Z" fill="#8b829b"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="460" rx="28" fill="url(#bg)"/>
+  <text x="600" y="62" text-anchor="middle" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="26" font-weight="700" fill="#302a3b">Many MCP servers. One connector.</text>
+  <text x="600" y="94" text-anchor="middle" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="16" fill="#756d82">Bring local stdio and remote HTTP tools to web AI clients through one self-hosted gateway.</text>
+
+  <g font-family="Inter,Segoe UI,Arial,sans-serif" filter="url(#shadow)">
+    <rect x="74" y="142" width="250" height="72" rx="16" fill="#fff" stroke="#e8dfe6"/>
+    <circle cx="112" cy="178" r="18" fill="#f8d8e5"/>
+    <text x="145" y="174" font-size="17" font-weight="700" fill="#302a3b">Local MCP</text>
+    <text x="145" y="196" font-size="14" fill="#756d82">npx · uvx · any stdio server</text>
+
+    <rect x="74" y="246" width="250" height="72" rx="16" fill="#fff" stroke="#e8dfe6"/>
+    <circle cx="112" cy="282" r="18" fill="#ded9fb"/>
+    <text x="145" y="278" font-size="17" font-weight="700" fill="#302a3b">Remote MCP</text>
+    <text x="145" y="300" font-size="14" fill="#756d82">HTTP · headers · OAuth</text>
+  </g>
+
+  <path d="M324 178 C390 178 390 210 450 210" fill="none" stroke="#8b829b" stroke-width="3" marker-end="url(#arrow)"/>
+  <path d="M324 282 C390 282 390 250 450 250" fill="none" stroke="#8b829b" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <g filter="url(#shadow)">
+    <rect x="466" y="138" width="268" height="184" rx="28" fill="url(#switch)"/>
+    <text x="600" y="204" text-anchor="middle" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="28" font-weight="800" fill="#fff">MCP Switch</text>
+    <rect x="520" y="225" width="160" height="35" rx="18" fill="#fff" fill-opacity=".18"/>
+    <text x="600" y="248" text-anchor="middle" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="14" font-weight="600" fill="#fff">one OAuth endpoint</text>
+    <text x="600" y="288" text-anchor="middle" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="14" fill="#f8f5ff">console · access scope · audit log</text>
+  </g>
+
+  <path d="M734 230 H860" fill="none" stroke="#8b829b" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <g font-family="Inter,Segoe UI,Arial,sans-serif" filter="url(#shadow)">
+    <rect x="876" y="142" width="250" height="176" rx="22" fill="#fff" stroke="#e8dfe6"/>
+    <text x="1001" y="184" text-anchor="middle" font-size="15" font-weight="700" fill="#8a3d68">WEB AI CLIENTS</text>
+    <rect x="912" y="207" width="178" height="36" rx="10" fill="#f8f4f7"/>
+    <text x="1001" y="231" text-anchor="middle" font-size="16" font-weight="600" fill="#302a3b">ChatGPT</text>
+    <rect x="912" y="255" width="178" height="36" rx="10" fill="#f4f2fc"/>
+    <text x="1001" y="279" text-anchor="middle" font-size="16" font-weight="600" fill="#302a3b">Claude · others</text>
+  </g>
+
+  <text x="600" y="393" text-anchor="middle" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="15" font-weight="600" fill="#554c63">Self-hosted · SQLite · transparent tool and MCP Apps relay</text>
+</svg>

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,11 +2,7 @@
 
 # MCP Switch
 
-**1 つの MCP エンドポイントで、ローカルとリモートのすべての MCP を集約。**
-
-セルフホスト型のゲートウェイ。ローカルとリモートの MCP サーバーを、
-OAuth で保護された 1 つのエンドポイントに集約し、MCP機能を搭載したあらゆるAI
-（claude.ai、ChatGPT など）へ公開します。
+**ローカルとリモートのすべての MCP サーバーを、ChatGPT や Claude などの Web AI で使える安全な 1 つのコネクタに。**
 
 ![license](https://img.shields.io/badge/license-MIT-e96ba8)
 ![node](https://img.shields.io/badge/node-%E2%89%A524-3c873a)
@@ -18,6 +14,8 @@ OAuth で保護された 1 つのエンドポイントに集約し、MCP機能�
 
 </div>
 
+![MCP Switch がローカルとリモートの MCP サーバーを 1 つのエンドポイントで Web AI へ接続](.github/assets/overview.svg)
+
 ---
 
 ## なぜ
@@ -25,14 +23,6 @@ OAuth で保護された 1 つのエンドポイントに集約し、MCP機能�
 Web/App の AI は**リモート** MCP にしか接続できず、しかもカスタムコネクタの枠は
 たいてい**1 つ**だけ。一方で便利な MCP の多くは**ローカル**の stdio プロセス
 （`npx`/`uvx`）で、Claude Desktop / CLI からしか起動できません。
-
-MCP Switch はその間に入ります：
-
-```
-   ローカル stdio MCP  ─┐
-                       ┼──►  MCP Switch  ──►  1 つの OAuth URL  ──►  claude.ai / ChatGPT / …
-   リモート HTTP MCP   ─┘     (あなたの VPS)
-```
 
 - 任意の数の MCP——リモート（URL）でもローカル（stdio、自分のマシンでホスト）でも——を 1 つのエンドポイントに**集約**。
 - **一度つなぐだけ。** AI には 1 つのコネクタだけが見え、その背後にすべてのツールがあります。

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 # MCP Switch
 
-**One MCP endpoint to rule them all.**
-
-Web- or app-based AIs are limited to remote MCP servers and typically offer only a single custom connector slot. In contrast, half of the most useful MCP servers run locally via standard I/O (like npx or uvx), making them accessible only to Claude Desktop or CLI tools.
+**Turn all your local and remote MCP servers into one secure connector for ChatGPT, Claude, and other web AI clients.**
 
 ![license](https://img.shields.io/badge/license-MIT-e96ba8)
 ![node](https://img.shields.io/badge/node-%E2%89%A524-3c873a)
@@ -18,6 +16,8 @@ Web- or app-based AIs are limited to remote MCP servers and typically offer only
 
 </div>
 
+![MCP Switch connects local and remote MCP servers to web AI clients through one endpoint](.github/assets/overview.svg)
+
 ---
 
 ## Why
@@ -25,14 +25,6 @@ Web- or app-based AIs are limited to remote MCP servers and typically offer only
 Web/app AIs can only connect to **remote** MCP servers, and most of them give you
 just **one** custom connector slot. Meanwhile half the useful MCP servers are
 **local** (`npx`/`uvx` stdio processes) that only Claude Desktop / a CLI can reach.
-
-MCP Switch sits in the middle:
-
-```
-   local stdio MCP  ─┐
-                     ┼──►  MCP Switch  ──►  one OAuth URL  ──►  claude.ai / ChatGPT / …
-   yet another MCP  ─┘     (your VPS)
-```
 
 - **Aggregate** any number of MCP servers — remote (URL) or local (stdio, hosted on
   your box) — into one endpoint.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,10 +2,7 @@
 
 # MCP Switch
 
-**一个 MCP 端点，聚合你所有的本地和远程 MCP。**
-
-一个自托管网关：把你的本地和远程 MCP 服务器聚合到一个 OAuth 保护的端点之后，
-再统一暴露给任意有 MCP 功能的 AI（claude.ai、ChatGPT 等）。
+**把所有本地和远程 MCP 服务器，变成一个可供 ChatGPT、Claude 等 Web AI 使用的安全连接器。**
 
 ![license](https://img.shields.io/badge/license-MIT-e96ba8)
 ![node](https://img.shields.io/badge/node-%E2%89%A524-3c873a)
@@ -17,20 +14,14 @@
 
 </div>
 
+![MCP Switch 通过一个端点把本地与远程 MCP 服务器连接到 Web AI](.github/assets/overview.svg)
+
 ---
 
 ## 为什么
 
 Web/App 端的 AI 只能连**远程** MCP，而且大多只给你**一个**自定义连接器名额；
 可很多有用的 MCP 是**本地** stdio 进程（`npx`/`uvx`），只有 Claude Desktop / CLI 能拉起。
-
-MCP Switch 夹在中间：
-
-```
-   本地 stdio MCP   ─┐
-                    ─┼──►  MCP Switch  ──►  一个 OAuth URL  ──►  claude.ai / ChatGPT / …
-   远程 HTTP MCP    ─┘     (你的 VPS)
-```
 
 - **聚合**任意多个 MCP——远程（URL）或本地（stdio，在你机器上托管）——到一个端点。
 - **连一次。** 你的 AI 只看到一个连接器，背后是你所有的工具。


### PR DESCRIPTION
## What changed

- replace the abstract tagline with one direct sentence explaining who MCP Switch is for and what it does
- add a compact visual overview above the fold
- remove the duplicated ASCII architecture diagram
- keep English, Simplified Chinese, and Japanese introductions aligned

This is intentionally a documentation-only change; setup details and technical reference remain intact.